### PR TITLE
[Refactor] 중간 지점 결과화면 및 목록 화면 개선

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,14 +5,45 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 import prettier from 'eslint-plugin-prettier';
 
-export default tseslint.config(
+// typescript-eslint 권장 설정 직접 가져오기
+const tsRecommended = {
+  linterOptions: {
+    reportUnusedDisableDirectives: true,
+  },
+  files: ['**/*.{ts,tsx}'],
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      sourceType: 'module',
+      projectService: true,
+    },
+  },
+  plugins: {
+    '@typescript-eslint': tseslint.plugin,
+  },
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-unused-vars': 'warn',
+  },
+};
+
+// prettier 설정
+const prettierConfig = {
+  files: ['**/*.{js,jsx,ts,tsx}'],
+  plugins: {
+    prettier: prettier,
+  },
+  rules: {
+    'prettier/prettier': 'error',
+  },
+};
+
+export default [
   { ignores: ['dist'] },
+  js.configs.recommended,
+  tsRecommended,
+  prettierConfig,
   {
-    extends: [
-      js.configs.recommended,
-      ...tseslint.configs.recommended,
-      'plugin:prettier/recommended',
-    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
@@ -21,7 +52,6 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
-      prettier,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
@@ -29,7 +59,6 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
-      'prettier/prettier': 'error',
     },
   },
-);
+];

--- a/src/components/skeleton/LocationRecommendationsSkeleton.tsx
+++ b/src/components/skeleton/LocationRecommendationsSkeleton.tsx
@@ -1,0 +1,69 @@
+const LocationRecommendationsSkeleton = () => {
+  // 추천 장소 항목 스켈레톤 생성
+  const recommendItems = Array(5)
+    .fill(0)
+    .map((_, index) => (
+      <div
+        key={index}
+        className="p-4 mb-3 bg-gray-100 rounded-lg animate-pulse ring-1 ring-primary"
+      >
+        <div className="flex items-start justify-between mb-[0.125rem]">
+          <div className="flex items-center gap-2">
+            <div className="bg-gray-200 rounded-full size-5"></div>
+            <div className="w-20 h-4 bg-gray-200 rounded"></div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 mt-2">
+          <div className="w-40 h-5 bg-gray-200 rounded"></div>
+          <div className="bg-gray-200 rounded-full size-3"></div>
+        </div>
+        <div className="w-48 h-4 mt-2 bg-gray-200 rounded"></div>
+      </div>
+    ));
+
+  return (
+    <>
+      <div className="hidden lg:block">
+        <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-4 pb-2">
+          <div className="w-48 h-8 ml-2 bg-gray-100 rounded animate-pulse"></div>
+          <div className="h-10 bg-gray-100 rounded animate-pulse"></div>
+        </div>
+        <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[0.4375rem]">
+          <div className="rounded-default h-[31.25rem] lg:h-[calc(100vh-10rem)] bg-gray-100 animate-pulse"></div>
+          <div className="space-y-3 animate-pulse">
+            {recommendItems}
+            <div className="flex items-center justify-center gap-3 py-4">
+              <div className="w-[2.5rem] h-8 bg-gray-200 rounded"></div>
+              <div className="w-12 h-4 bg-gray-200 rounded"></div>
+              <div className="w-[2.5rem] h-8 bg-gray-200 rounded"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="lg:hidden">
+        <div className="fixed inset-0 top-[4.75rem] bg-gray-100 animate-pulse"></div>
+        <div className="fixed bottom-0 left-0 right-0 bg-white shadow-md rounded-t-2xl">
+          <div className="flex flex-col h-full">
+            <div className="sticky top-0 px-4 py-3">
+              <div className="w-40 h-5 mb-3 bg-gray-200 rounded animate-pulse"></div>
+              <div className="w-full h-10 bg-gray-200 rounded animate-pulse"></div>
+            </div>
+            <div className="px-4">
+              <div className="mt-4 space-y-3 animate-pulse">
+                {recommendItems[0]}
+              </div>
+              <div className="flex items-center justify-center gap-3 py-4 animate-pulse">
+                <div className="w-[2.5rem] h-8 bg-gray-200 rounded"></div>
+                <div className="w-12 h-4 bg-gray-200 rounded"></div>
+                <div className="w-[2.5rem] h-8 bg-gray-200 rounded"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LocationRecommendationsSkeleton;

--- a/src/components/skeleton/LocationResultSkeleton.tsx
+++ b/src/components/skeleton/LocationResultSkeleton.tsx
@@ -1,0 +1,63 @@
+const LocationResultSkeleton = () => {
+  // 5개의 중간지점 항목을 표시하는 스켈레톤 생성
+  const midpointItems = Array(5)
+    .fill(0)
+    .map((_, index) => (
+      <li
+        key={index}
+        className="flex flex-col justify-center h-full p-4 bg-gray-100 shadow-sm rounded-default animate-pulse"
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="bg-gray-200 rounded-full size-6"></div>
+            <div className="w-32 h-4 bg-gray-200 rounded"></div>
+          </div>
+        </div>
+        <div className="flex items-center my-2">
+          <div className="w-40 h-5 mt-1 bg-gray-200 rounded"></div>
+        </div>
+        <div className="w-48 h-4 mt-1 bg-gray-200 rounded"></div>
+      </li>
+    ));
+
+  return (
+    <>
+      <div className="hidden lg:grid w-full grid-cols-1 lg:grid-cols-10 px-4 lg:px-[7.5rem] gap-[1.25rem] lg:gap-[0.625rem] mt-[1.5625rem]">
+        <div className="rounded-default h-[31.25rem] lg:min-h-[calc(100vh-8rem)] lg:col-span-6 bg-gray-100 animate-pulse"></div>
+        <div className="lg:col-span-4 lg:max-h-[calc(100vh-8rem)]">
+          <ul className="grid grid-cols-1 grid-rows-5 h-full gap-[0.625rem]">
+            {midpointItems}
+          </ul>
+        </div>
+      </div>
+
+      <div className="lg:hidden">
+        <div className="fixed inset-0 top-[4.75rem] bg-gray-100 animate-pulse"></div>
+        <div className="fixed bottom-0 left-0 right-0">
+          <div className="relative w-full pb-6">
+            <div className="flex gap-2 p-4 overflow-x-auto snap-x snap-mandatory scrollbar-hide">
+              <div className="snap-center shrink-0 first:pl-0 last:pr-4 w-[calc(100dvw-5rem)]">
+                <div className="bg-white-default">
+                  <div className="flex flex-col justify-center h-32 p-4 bg-gray-100 shadow-sm rounded-default animate-pulse">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <div className="bg-gray-200 rounded-full size-6"></div>
+                        <div className="w-32 h-4 bg-gray-200 rounded"></div>
+                      </div>
+                    </div>
+                    <div className="flex items-center my-2">
+                      <div className="w-40 h-5 mt-1 bg-gray-200 rounded"></div>
+                    </div>
+                    <div className="w-48 h-4 mt-1 bg-gray-200 rounded"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LocationResultSkeleton;

--- a/src/pages/location/LocationResultPage.tsx
+++ b/src/pages/location/LocationResultPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import KakaoMap from '@src/components/common/kakao/KakaoMap';
 import { useMidpointSearchQuery } from '@src/state/queries/location/useMidpointSearchQuery';
 import { useGetPlaceSearchQuery } from '@src/state/queries/location/useGetPlaceSearchQuery';
@@ -9,46 +9,85 @@ import { useCoordinates } from '@src/hooks/location/useCoordinates';
 import { SEQUENCE } from '@src/components/location/constants';
 import SearchLocationLoading from '@src/components/loading/SearchLocationLoading';
 import LocationEnterErrorPage from '@src/components/location/LocationEnterErrorPage';
+import LocationResultSkeleton from '@src/components/skeleton/LocationResultSkeleton';
 
 export default function LocationResultPage() {
-  const [isLoading, setIsLoading] = useState(true);
+  // 앱 최초 로드 여부를 세션 스토리지에 저장하여 확인
+  const [isInitialAppLoad, setIsInitialAppLoad] = useState(() => {
+    return sessionStorage.getItem('hasLoadedMidpointResult') !== 'true';
+  });
   const [selectedLocationIndex, setSelectedLocationIndex] = useState(0);
+  // 중간지점 변경 중일 때는 로딩 인디케이터를 표시하지 않음
+  const [isChangingLocation, setIsChangingLocation] = useState(false);
 
   const { data: placeSearchData, isLoading: isPlaceSearchLoading } =
     useGetPlaceSearchQuery();
-  const { data: midpointSearchData } = useMidpointSearchQuery({
+  const {
+    data: midpointSearchData,
+    isLoading: isMidpointSearchLoading,
+    isFetching: isMidpointFetching,
+  } = useMidpointSearchQuery({
     enabled:
       placeSearchData?.data?.myLocationExistence ||
       placeSearchData?.data?.friendLocationExistence,
   });
 
   const selectedMidpoint = midpointSearchData?.data[selectedLocationIndex];
-  const { data: timeSearchData, refetch: refetchMidpointTimeSearch } =
-    useMidpointTimeSearchQuery(
-      selectedMidpoint?.addressLat || 0,
-      selectedMidpoint?.addressLong || 0,
-      {
-        enabled:
-          !!midpointSearchData?.data &&
-          !!selectedMidpoint &&
-          selectedMidpoint.addressLat !== 0 &&
-          selectedMidpoint.addressLong !== 0,
-      },
-    );
+  const {
+    data: timeSearchData,
+    isFetching: isTimeFetching,
+    refetch: refetchMidpointTimeSearch,
+  } = useMidpointTimeSearchQuery(
+    selectedMidpoint?.addressLat || 0,
+    selectedMidpoint?.addressLong || 0,
+    {
+      enabled:
+        !!midpointSearchData?.data &&
+        !!selectedMidpoint &&
+        selectedMidpoint.addressLat !== 0 &&
+        selectedMidpoint.addressLong !== 0,
+    },
+  );
 
+  // 중간지점 선택 핸들러 - 시간 정보는 백그라운드에서 조용히 불러옴
+  const handleLocationSelect = useCallback((index: number) => {
+    setIsChangingLocation(true);
+    setSelectedLocationIndex(index);
+    // 위치가 변경되면 이전 데이터를 계속 사용하면서 새 데이터를 백그라운드에서 로드
+  }, []);
+
+  // 중간지점이 변경되면 시간 정보 다시 가져오기
   useEffect(() => {
     if (selectedMidpoint?.addressLat && selectedMidpoint?.addressLong) {
-      refetchMidpointTimeSearch();
+      refetchMidpointTimeSearch().finally(() => {
+        // 데이터 로딩이 완료되면 위치 변경 상태 해제
+        setIsChangingLocation(false);
+      });
     }
   }, [selectedMidpoint, refetchMidpointTimeSearch]);
 
+  // 최초 앱 로드 시에만 로딩 화면 표시, 데이터 로드 완료 후 세션 스토리지에 표시 완료 저장
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 1500);
+    if (
+      isInitialAppLoad &&
+      !isPlaceSearchLoading &&
+      !isMidpointSearchLoading &&
+      midpointSearchData
+    ) {
+      // 최초 로딩이 완료되면 세션 스토리지에 저장
+      const timer = setTimeout(() => {
+        sessionStorage.setItem('hasLoadedMidpointResult', 'true');
+        setIsInitialAppLoad(false);
+      }, 1000);
 
-    return () => clearTimeout(timer);
-  }, []);
+      return () => clearTimeout(timer);
+    }
+  }, [
+    isInitialAppLoad,
+    isPlaceSearchLoading,
+    isMidpointSearchLoading,
+    midpointSearchData,
+  ]);
 
   const coordinates = useCoordinates(
     placeSearchData,
@@ -57,22 +96,52 @@ export default function LocationResultPage() {
     timeSearchData,
   );
 
-  if (isLoading) return <SearchLocationLoading />;
+  // 최초 앱 로드 시에는 로딩 화면 표시
+  if (isInitialAppLoad) {
+    return <SearchLocationLoading />;
+  }
+
+  // 초기 데이터 로딩 중일 때만 스켈레톤 UI 표시
   if (
-    !isPlaceSearchLoading &&
+    isPlaceSearchLoading ||
+    !placeSearchData ||
+    (isMidpointSearchLoading && !midpointSearchData)
+  ) {
+    return <LocationResultSkeleton />;
+  }
+
+  // 장소 정보가 없는 경우 에러 페이지 표시
+  if (
     !placeSearchData?.data?.myLocationExistence &&
     !placeSearchData?.data?.friendLocationExistence
-  )
+  ) {
     return <LocationEnterErrorPage />;
-  if (!midpointSearchData) return <LocationEnterErrorPage />;
+  }
+
+  // 데이터 새로고침 중인지 여부를 확인 (필터 변경이나 페이지 전환 시)
+  // 중간지점 변경 중에는 로딩 인디케이터를 표시하지 않음
+  const isRefreshing =
+    !isChangingLocation &&
+    ((isMidpointFetching && midpointSearchData) ||
+      (isTimeFetching && timeSearchData));
 
   return (
     <>
       <div className="hidden lg:grid w-full grid-cols-1 lg:grid-cols-10 px-4 lg:px-[7.5rem] gap-[1.25rem] lg:gap-[0.625rem] mt-[1.5625rem]">
-        <div className="rounded-default h-[31.25rem] lg:min-h-[calc(100vh-8rem)] lg:col-span-6">
+        <div className="rounded-default h-[31.25rem] lg:min-h-[calc(100vh-8rem)] lg:col-span-6 relative">
+          {isRefreshing && (
+            <div className="absolute z-10 top-2 right-2">
+              <div className="w-6 h-6 rounded-full border-3 border-blue-light01 border-t-blue-normal01 animate-spin"></div>
+            </div>
+          )}
           <KakaoMap coordinates={coordinates} />
         </div>
-        <div className="lg:col-span-4 lg:max-h-[calc(100vh-8rem)]">
+        <div className="lg:col-span-4 lg:max-h-[calc(100vh-8rem)] relative">
+          {isRefreshing && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/50">
+              <div className="w-8 h-8 border-4 rounded-full border-blue-light01 border-t-blue-normal01 animate-spin"></div>
+            </div>
+          )}
           <ul className="grid grid-cols-1 grid-rows-5 h-full gap-[0.625rem]">
             {midpointSearchData.data.map(
               (location: IMidpointDataResponseType, index: number) => (
@@ -82,7 +151,7 @@ export default function LocationResultPage() {
                   index={index}
                   isSelected={selectedLocationIndex === index}
                   sequence={SEQUENCE[index]}
-                  onSelect={() => setSelectedLocationIndex(index)}
+                  onSelect={() => handleLocationSelect(index)}
                 />
               ),
             )}
@@ -92,11 +161,21 @@ export default function LocationResultPage() {
 
       <div className="lg:hidden">
         <div className="fixed inset-0 top-[4.75rem]">
+          {isRefreshing && (
+            <div className="absolute z-10 top-2 right-2">
+              <div className="w-6 h-6 rounded-full border-3 border-blue-light01 border-t-blue-normal01 animate-spin"></div>
+            </div>
+          )}
           <KakaoMap coordinates={coordinates} />
         </div>
         <div className="fixed bottom-0 left-0 right-0">
           <div className="relative w-full pb-6">
-            <div className="flex gap-2 p-4 overflow-x-auto snap-x snap-mandatory scrollbar-hide">
+            <div className="relative flex gap-2 p-4 overflow-x-auto snap-x snap-mandatory scrollbar-hide">
+              {isRefreshing && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/50">
+                  <div className="w-8 h-8 border-4 rounded-full border-blue-light01 border-t-blue-normal01 animate-spin"></div>
+                </div>
+              )}
               {midpointSearchData.data.map(
                 (location: IMidpointDataResponseType, index: number) => (
                   <div
@@ -109,7 +188,7 @@ export default function LocationResultPage() {
                         index={index}
                         isSelected={selectedLocationIndex === index}
                         sequence={SEQUENCE[index]}
-                        onSelect={() => setSelectedLocationIndex(index)}
+                        onSelect={() => handleLocationSelect(index)}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
Resolves: #235 

## PR 유형
- [x] 새로운 기능 추가

## 작업 내용

🚨 [문제 상황]
SyncSpot 앱의 중간지점 결과 페이지와 추천 목록 페이지에서 페이지 전환 시 전체 화면이 로딩 인디케이터로 가려지는 문제가 있었습니다. 또한 중간지점 선택 시 파란색 로더가 깜빡이는 현상이 발생해 사용자 경험을 저해했습니다. 특히 이미 데이터를 가지고 있는 상태에서도 새로운 데이터를 요청할 때마다 전체 화면에 로딩 인디케이터가 표시되어 UX가 부자연스러웠습니다.

🛠️ [문제 해결 과정]
먼저 페이지별로 적합한 스켈레톤 UI 컴포넌트(LocationResultSkeleton, LocationRecommendationsSkeleton)를 구현했습니다. 
그 다음 세션 스토리지를 활용해 앱의 최초 로드 여부를 관리하도록 구성했는데, 이를 통해 최초 로드 시에만 전체 화면 로더를 표시하고 이후에는 스켈레톤 UI로 전환되도록 했습니다. 마지막으로 중간지점 변경 시 깜빡임 문제를 해결하기 위해 isChangingLocation과 isFiltering 같은 상태를 추가하여, 이전 데이터를 유지하면서 백그라운드에서 새 데이터를 조용히 로드하는 방식으로 개선했습니다.

🎯 [결과]
데이터 로딩 방식을 개선하여 기존 데이터를 유지하면서 백그라운드에서 새 데이터를 로드하도록 변경했습니다. 불필요한 로딩 화면을 최소화하고 필요한 경우에만 인디케이터를 표시하여 사용자 경험을 향상시키고자 하였습니다. 
결과적으로 중간지점 변경 시 UI가 깜빡이는 문제를 해결하여 화면 전환이 부드럽게 이루어지도록 개선했으며, 앱 최초 로드 이후에는 스켈레톤 UI를 활용해 로딩 과정에서도 앱의 구조를 사용자에게 미리 보여줄 수 있게 되었습니다.

## 스크린샷

### 개선 이전의 문제 화면
![2025-05-05 Video to GIF Converter](https://github.com/user-attachments/assets/84a5be6b-9301-4cc0-9900-6baff4f330c9)


### 개선된 화면
![2025-05-0512 12 03-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/eb2b16ac-83f5-4306-bc14-5fdfb82d20ca)



## 공유사항 to 리뷰어
- 스켈레톤 적용이 적절한지

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 위치 추천 및 결과 페이지에 스켈레톤(로딩) UI가 추가되어 데이터 로딩 중에도 시각적 피드백을 제공합니다.
    - 초기 앱 로딩, 필터링, 데이터 새로고침 등 다양한 로딩 상태에 따라 맞춤형 로딩 화면과 스피너가 표시됩니다.

- **Bug Fixes**
    - 데이터 로딩 및 필터링 시 사용자 경험이 개선되어, 로딩 상태가 명확하게 구분되어 표시됩니다.

- **Refactor**
    - ESLint 설정이 모듈화되어 관리가 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->